### PR TITLE
Add Mulch to browsers.inc

### DIFF
--- a/zygisk_module/jni/browsers.inc
+++ b/zygisk_module/jni/browsers.inc
@@ -45,3 +45,4 @@
 "com.stoutner.privacybrowser.free",
 "com.stoutner.privacybrowser.standard",
 "com.naver.whale",
+"us.spotco.mulch",


### PR DESCRIPTION
Mulch
This is a security oriented web browser based on Chromium. It includes many patches from the Vanadium project, plus some extras from the Bromite project. The source repo also includes prebuilts and makefiles to allow other ROMs to include Mulch as their system WebView.

https://gitlab.com/divested-mobile/mulch

**Note:** right now the browser is not affected by this problem, but a future release may show similar behaviors to bromite, so I think adding it to browsers.inc is a good thing.