### PR TITLE
fix cert sort

### DIFF
--- a/module/module.prop
+++ b/module/module.prop
@@ -1,6 +1,6 @@
 id=adguardcert
 name=AdGuard Certificate
-version=v2.0-beta2
-versionCode=31
+version=v2.0-beta3
+versionCode=32
 author=AdGuard
 description=Moves AdGuard's root CA certificate from the user certificate store to the system certificate store.

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -20,8 +20,8 @@ MODDIR=${0%/*}
 #    Apps will reject certs that are in the `cacerts-removed`.
 AG_CERT_HASH=0f4ed297
 AG_INTERMEDIATE_CERT_HASH=47ec1af8
-AG_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_CERT_HASH}.* | sort | tail -n1)
-AG_INTERMEDIATE_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_INTERMEDIATE_CERT_HASH}.* | sort | tail -n1)
+AG_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read left right; echo $right))
+AG_INTERMEDIATE_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_INTERMEDIATE_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read left right; echo $right))
 
 if [ -e "${AG_CERT_FILE}" ] && [ -e "${AG_INTERMEDIATE_CERT_FILE}" ]; then
     cp -f ${AG_CERT_FILE} ${MODDIR}/system/etc/security/cacerts/${AG_CERT_HASH}.0

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -20,8 +20,8 @@ MODDIR=${0%/*}
 #    Apps will reject certs that are in the `cacerts-removed`.
 AG_CERT_HASH=0f4ed297
 AG_INTERMEDIATE_CERT_HASH=47ec1af8
-AG_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read left right; echo $right))
-AG_INTERMEDIATE_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_INTERMEDIATE_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read left right; echo $right))
+AG_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read -r left right; echo $right))
+AG_INTERMEDIATE_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_INTERMEDIATE_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read -r left right; echo $right))
 
 if [ -e "${AG_CERT_FILE}" ] && [ -e "${AG_INTERMEDIATE_CERT_FILE}" ]; then
     cp -f ${AG_CERT_FILE} ${MODDIR}/system/etc/security/cacerts/${AG_CERT_HASH}.0


### PR DESCRIPTION
Fixed behavior caused by sorting that would select `<hash>.9` even if a `<hash>.10` certificate was present