### PR TITLE
Android 14 support

### DIFF
--- a/module/module.prop
+++ b/module/module.prop
@@ -1,6 +1,6 @@
 id=adguardcert
 name=AdGuard Certificate
-version=v2.0-beta4
-versionCode=33
+version=v2.0-beta5
+versionCode=34
 author=AdGuard
 description=Moves AdGuard's root CA certificate from the user certificate store to the system certificate store.

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -1,5 +1,24 @@
 #!/system/bin/sh
+
+exec > /data/local/tmp/adguardcert.log
+exec 2>&1
+
+set -x
+
 MODDIR=${0%/*}
+
+set_context() {
+    [ "$(getenforce)" = "Enforcing" ] || return 0
+
+    default_selinux_context=u:object_r:system_file:s0
+    selinux_context=$(ls -Zd $1 | awk '{print $1}')
+
+    if [ -n "$selinux_context" ] && [ "$selinux_context" != "?" ]; then
+        chcon -R $selinux_context $2
+    else
+        chcon -R $default_selinux_context $2
+    fi
+}
 
 # Android hashes the subject to get the filename, field order is significant.
 # (`openssl x509 -in ... -noout -hash`)
@@ -18,20 +37,36 @@ MODDIR=${0%/*}
 AG_CERT_HASH=0f4ed297
 AG_CERT_FILE=$(ls /data/misc/user/*/cacerts-added/${AG_CERT_HASH}.* | (IFS=.; while read -r left right; do echo $right $left.$right; done) | sort -nr | (read -r left right; echo $right))
 
-if [ -e "${AG_CERT_FILE}" ]; then
-    cp -f ${AG_CERT_FILE} ${MODDIR}/system/etc/security/cacerts/${AG_CERT_HASH}.0
-    rm -f /data/misc/user/*/cacerts-removed/${AG_CERT_HASH}.*
+if ! [ -e "${AG_CERT_FILE}" ]; then
+    exit 0
 fi
 
+rm -f /data/misc/user/*/cacerts-removed/${AG_CERT_HASH}.*
+
+cp -f ${AG_CERT_FILE} ${MODDIR}/system/etc/security/cacerts/${AG_CERT_HASH}.0
 chown -R 0:0 ${MODDIR}/system/etc/security/cacerts
+set_context /system/etc/security/cacerts $MODDIR/system/etc/security/cacerts
 
-[ "$(getenforce)" = "Enforcing" ] || exit 0
+# Android 14 support
+# Since Magisk ignore /apex for module file injections, use non-Magisk way
+if [ -e /apex/com.android.conscrypt/cacerts ]; then
+    # Clone directory into tmpfs
+    mkdir -p /data/local/tmp-ca-copy
+    mount -t tmpfs tmpfs /data/local/tmp/tmp-ca-copy
+    cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/tmp-ca-copy
 
-default_selinux_context=u:object_r:system_file:s0
-selinux_context=$(ls -Zd /system/etc/security/cacerts | awk '{print $1}')
+    # Do the same as in Magisk module
+    cp -f ${AG_CERT_FILE} /data/local/tmp/tmp-ca-copy
+    chown -R 0:0 /data/local/tmp/tmp-ca-copy
+    set_context /apex/com.android.conscrypt/cacerts /data/local/tmp/tmp-ca-copy
 
-if [ -n "$selinux_context" ] && [ "$selinux_context" != "?" ]; then
-    chcon -R $selinux_context $MODDIR/system/etc/security/cacerts
-else
-    chcon -R $default_selinux_context $MODDIR/system/etc/security/cacerts
+    # Mount directory inside APEX if it is valid, and remove temporary one.
+    CERTS_NUM="$(ls -1 /apex/com.android.conscrypt/cacerts | wc -l)"
+    if [ "$CERTS_NUM" -gt 10 ]; then
+        mount --bind /data/local/tmp/tmp-ca-copy /apex/com.android.conscrypt/cacerts
+    else
+        echo "Cancelling replacing CA storage due to safety"
+    fi
+    umount /data/local/tmp/tmp-ca-copy
+    rmdir /data/local/tmp/tmp-ca-copy
 fi

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -45,11 +45,11 @@ rm -f /data/misc/user/*/cacerts-removed/${AG_CERT_HASH}.*
 
 cp -f ${AG_CERT_FILE} ${MODDIR}/system/etc/security/cacerts/${AG_CERT_HASH}.0
 chown -R 0:0 ${MODDIR}/system/etc/security/cacerts
-set_context /system/etc/security/cacerts $MODDIR/system/etc/security/cacerts
+set_context /system/etc/security/cacerts ${MODDIR}/system/etc/security/cacerts
 
 # Android 14 support
 # Since Magisk ignore /apex for module file injections, use non-Magisk way
-if [ -e /apex/com.android.conscrypt/cacerts ]; then
+if [ -d /apex/com.android.conscrypt/cacerts ]; then
     # Clone directory into tmpfs
     rm -f /data/local/tmp/tmp-ca-copy
     mkdir -p /data/local/tmp/tmp-ca-copy

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -61,7 +61,7 @@ if [ -e /apex/com.android.conscrypt/cacerts ]; then
     set_context /apex/com.android.conscrypt/cacerts /data/local/tmp/tmp-ca-copy
 
     # Mount directory inside APEX if it is valid, and remove temporary one.
-    CERTS_NUM="$(ls -1 /apex/com.android.conscrypt/cacerts | wc -l)"
+    CERTS_NUM="$(ls -1 /data/local/tmp/tmp-ca-copy | wc -l)"
     if [ "$CERTS_NUM" -gt 10 ]; then
         mount --bind /data/local/tmp/tmp-ca-copy /apex/com.android.conscrypt/cacerts
     else

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -51,23 +51,23 @@ set_context /system/etc/security/cacerts ${MODDIR}/system/etc/security/cacerts
 # Since Magisk ignore /apex for module file injections, use non-Magisk way
 if [ -d /apex/com.android.conscrypt/cacerts ]; then
     # Clone directory into tmpfs
-    rm -f /data/local/tmp/tmp-ca-copy
-    mkdir -p /data/local/tmp/tmp-ca-copy
-    mount -t tmpfs tmpfs /data/local/tmp/tmp-ca-copy
-    cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/tmp-ca-copy/
+    rm -f /data/local/tmp/adg-ca-copy
+    mkdir -p /data/local/tmp/adg-ca-copy
+    mount -t tmpfs tmpfs /data/local/tmp/adg-ca-copy
+    cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/adg-ca-copy/
 
     # Do the same as in Magisk module
-    cp -f ${AG_CERT_FILE} /data/local/tmp/tmp-ca-copy
-    chown -R 0:0 /data/local/tmp/tmp-ca-copy
-    set_context /apex/com.android.conscrypt/cacerts /data/local/tmp/tmp-ca-copy
+    cp -f ${AG_CERT_FILE} /data/local/tmp/adg-ca-copy
+    chown -R 0:0 /data/local/tmp/adg-ca-copy
+    set_context /apex/com.android.conscrypt/cacerts /data/local/tmp/adg-ca-copy
 
     # Mount directory inside APEX if it is valid, and remove temporary one.
-    CERTS_NUM="$(ls -1 /data/local/tmp/tmp-ca-copy | wc -l)"
+    CERTS_NUM="$(ls -1 /data/local/tmp/adg-ca-copy | wc -l)"
     if [ "$CERTS_NUM" -gt 10 ]; then
-        mount --bind /data/local/tmp/tmp-ca-copy /apex/com.android.conscrypt/cacerts
+        mount --bind /data/local/tmp/adg-ca-copy /apex/com.android.conscrypt/cacerts
     else
         echo "Cancelling replacing CA storage due to safety"
     fi
-    umount /data/local/tmp/tmp-ca-copy
-    rmdir /data/local/tmp/tmp-ca-copy
+    umount /data/local/tmp/adg-ca-copy
+    rmdir /data/local/tmp/adg-ca-copy
 fi

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -51,9 +51,10 @@ set_context /system/etc/security/cacerts $MODDIR/system/etc/security/cacerts
 # Since Magisk ignore /apex for module file injections, use non-Magisk way
 if [ -e /apex/com.android.conscrypt/cacerts ]; then
     # Clone directory into tmpfs
-    mkdir -p /data/local/tmp-ca-copy
+    rm -f /data/local/tmp/tmp-ca-copy
+    mkdir -p /data/local/tmp/tmp-ca-copy
     mount -t tmpfs tmpfs /data/local/tmp/tmp-ca-copy
-    cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/tmp-ca-copy
+    cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/tmp-ca-copy/
 
     # Do the same as in Magisk module
     cp -f ${AG_CERT_FILE} /data/local/tmp/tmp-ca-copy


### PR DESCRIPTION
#### Problem and solution

Android 14 changed the place of system certificates from `/system/etc/security/cacerts` to `/apex/com.android.conscrypt/cacerts`. The benefit is that APEX may be installed independently from system.

But there is a problem - Magisk does not inject module files into /apex directory.

So we do not rely to Magisk file injection and instead use our own tmpfs clone.

Thanks to [blog of "HTTP Toolkit"](https://httptoolkit.com/blog/android-14-install-system-ca-certificate/) for some ideas, even though our solution is slightly different.

#### Why module copying and other magic should be done in `post-fs-data` boot phase?

In last Android releases, there are mount namespaces, that are cloned for every process, so it is difficult to setup bind mounts after system boot. So any interventions should be done before boot phase (on post-fs-data phase).

Resolves #32
