### PR TITLE
Fix moving cert on Android 14 with Magisk Canary 26.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,6 @@ jobs:
 
       - name: build dist
         run: |
-          git submodule init && git submodule update
           ./dist.sh
           ls -la
 
@@ -28,6 +27,7 @@ jobs:
           artifacts: "adguardcert-*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: true
+          prerelease: ${{ contains(github.ref, '-') }}
 
       - name: write PR url
         if: github.event_name == 'pull_request'
@@ -43,3 +43,10 @@ jobs:
             adguardcert-*.zip
             README.md
             pull_request_url.txt
+
+      - name: update json
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ./update.sh
+          git push origin master
+          ls -la

--- a/module/module.prop
+++ b/module/module.prop
@@ -1,6 +1,6 @@
 id=adguardcert
 name=AdGuard Certificate
-version=v2.0
+version=v2.1-beta1
 versionCode=35
 author=AdGuard
 description=Moves AdGuard's root CA certificate from the user certificate store to the system certificate store.

--- a/module/module.prop
+++ b/module/module.prop
@@ -1,7 +1,7 @@
 id=adguardcert
 name=AdGuard Certificate
-version=v2.1-beta1
-versionCode=35
+version=v2.1
+versionCode=36
 author=AdGuard
 description=Moves AdGuard's root CA certificate from the user certificate store to the system certificate store.
 updateJson=https://raw.githubusercontent.com/AdguardTeam/adguardcert/master/update.json

--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -57,7 +57,7 @@ if [ -d /apex/com.android.conscrypt/cacerts ]; then
     cp -f /apex/com.android.conscrypt/cacerts/* /data/local/tmp/adg-ca-copy/
 
     # Do the same as in Magisk module
-    cp -f ${AG_CERT_FILE} /data/local/tmp/adg-ca-copy
+    cp -f ${AG_CERT_FILE} /data/local/tmp/adg-ca-copy/${AG_CERT_HASH}.0
     chown -R 0:0 /data/local/tmp/adg-ca-copy
     set_context /apex/com.android.conscrypt/cacerts /data/local/tmp/adg-ca-copy
 
@@ -65,6 +65,10 @@ if [ -d /apex/com.android.conscrypt/cacerts ]; then
     CERTS_NUM="$(ls -1 /data/local/tmp/adg-ca-copy | wc -l)"
     if [ "$CERTS_NUM" -gt 10 ]; then
         mount --bind /data/local/tmp/adg-ca-copy /apex/com.android.conscrypt/cacerts
+        for pid in 1 $(pgrep zygote) $(pgrep zygote64); do
+            nsenter --mount=/proc/${pid}/ns/mnt -- \
+                /bin/mount --bind /data/local/tmp/adg-ca-copy /apex/com.android.conscrypt/cacerts
+        done
     else
         echo "Cancelling replacing CA storage due to safety"
     fi

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-  "version": "v2.0",
-  "versionCode": 35,
-  "zipUrl": "https://github.com/AdguardTeam/adguardcert/releases/download/v2.0/adguardcert-v2.0.zip",
-  "changelog": "https://github.com/AdguardTeam/adguardcert/releases/tag/v2.0"
+  "version": "v2.1",
+  "versionCode": 36,
+  "zipUrl": "https://github.com/AdguardTeam/adguardcert/releases/download/v2.1/adguardcert-v2.1.zip",
+  "changelog": "https://github.com/AdguardTeam/adguardcert/releases/tag/v2.1"
 }

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+case version in
+*-*)
+    ;;
+*)
+    git checkout -B master origin/master
+    cat module/module.prop | (
+    IFS="="
+    while read k v; do
+        read $k <<< "$v"
+    done
+    cat << EOF > update.json
+{
+  "version": "$version",
+  "versionCode": $versionCode,
+  "zipUrl": "https://github.com/AdguardTeam/adguardcert/releases/download/$version/adguardcert-$version.zip",
+  "changelog": "https://github.com/AdguardTeam/adguardcert/releases/tag/$version"
+}
+EOF
+    )
+    git add update.json
+    git commit -m "skipci: Update update.json"
+    ;;
+esac


### PR DESCRIPTION
Seems that post-fs-data.sh is now executed on a separate mount namespace.

Closes #52